### PR TITLE
aqua global setting ほか

### DIFF
--- a/dot_gitconfig
+++ b/dot_gitconfig
@@ -28,3 +28,6 @@
 
 [push]
   default = nothing
+
+[color]
+  branch = true

--- a/dot_gitconfig
+++ b/dot_gitconfig
@@ -21,8 +21,7 @@
   # https://git-scm.com/docs/git-rebase#Documentation/git-rebase.txt--r
   rebase-r = rebase -r
   version-tags = tag -l --sort=-v:refname
-  # 外部コマンドを実行するためにコマンドの先頭に ! をつける
-  branch-ref = "!git for-each-ref --sort=-committerdate --format='%(color:yellow)%(refname:short)%(color:reset) %(subject)' refs/heads/"
+  branch-ref = "branch -v"
 
 [include]
   path = ~/.gitconfig.work

--- a/dot_zshrc
+++ b/dot_zshrc
@@ -42,6 +42,8 @@ zinit light-mode for \
 ### Start original custom
 eval "$(starship init zsh)"
 
+export AQUA_GLOBAL_CONFIG=${AQUA_GLOBAL_CONFIG:-}:${XDG_CONFIG_HOME:-$HOME/.config}/aquaproj-aqua/aqua.yaml
+
 zinit light asdf-vm/asdf
 
 zinit ice as"program" from"gh-r" \

--- a/dot_zshrc
+++ b/dot_zshrc
@@ -46,13 +46,13 @@ export AQUA_GLOBAL_CONFIG=${AQUA_GLOBAL_CONFIG:-}:${XDG_CONFIG_HOME:-$HOME/.conf
 
 zinit light asdf-vm/asdf
 
-zinit ice as"program" from"gh-r" \
-  mv"jq-* -> jq" \
-  pick"jq" \
-  bpick"jq-linux64"
-zinit light jqlang/jq
-
 if [[ $(uname) == "Darwin" && $(uname -m) == "x86_64" ]]; then
+  zinit ice as"program" from"gh-r" \
+    mv"jq-* -> jq" \
+    pick"jq" \
+    bpick"jq-osx-amd64"
+  zinit light jqlang/jq
+
   zinit ice as"program" from"gh-r" \
     pick"fzf" \
     bpick"fzf-*-darwin_amd64.zip"


### PR DESCRIPTION
## やったこと

- aqua の global install ができるようにする global setting
- jq がなんか linux 用で mac では動かなくなってたぽいので mac 用の記述に変更
- `git branch-ref` だがいちいち難しいスクリプト書かなくてもおおまかの機能が同じオプションがあったのでそちらに修正