### PR TITLE
:desert_island: macos AquaSKK に CTRL - q の設定があり tmux prefix がつかえなくなってた

### DIFF
--- a/private_dot_config/wezterm/wezterm.lua
+++ b/private_dot_config/wezterm/wezterm.lua
@@ -24,6 +24,10 @@ config.harfbuzz_features = { 'calt=0', 'clig=0', 'liga=0' }
 
 config.macos_forward_to_ime_modifier_mask = 'SHIFT|CTRL'
 
+if wezterm.target_triple == 'x86_64-apple-darwin' then
+  { mods = "CTRL", key = "q", action=wezterm.action{ SendString="\x11" } },
+end
+
 -- and finally, return the configuration to wezterm
 return config
 


### PR DESCRIPTION
tmux prefix を CTRL - q に指定しているので、設定を追加